### PR TITLE
fix url from `https://rye-up.com/get` to `https://rye.astral.sh/get`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
         curl
 
 SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
-RUN curl -sSf https://rye-up.com/get | RYE_INSTALL_OPTION="--yes" bash && \
+RUN curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash && \
     rye config --set-bool behavior.global-python=true && \
     rye config --set-bool behavior.use-uv=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
         curl
 
 SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
-RUN curl -sSf https://rye-up.com/get | RYE_INSTALL_OPTION="--yes" bash && \
+RUN curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash && \
     rye config --set-bool behavior.global-python=true && \
     rye config --set-bool behavior.use-uv=true
 


### PR DESCRIPTION
# Why need this PR
The URL to download Rye has been changed and Docker does not start properly.